### PR TITLE
Add meta generator tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="generator" content="Jekyll v{{ jekyll.version }}">
 
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">


### PR DESCRIPTION
First, it shows the open source product we use to maintain our website.
And second, when we run into a problem, we can see which version of
Jekyll is used, either on GH pages as well as local.
