### PR TITLE
Add meta description tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">


### PR DESCRIPTION
This tag is used by Google to show in the search results.
So it is important to set. The site description can be
overwritten by a page description.
