### PR TITLE
Fix warning when generating site locally

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
The layout tag is not needed in the Front Matter. Just the two lines
of dashes is enough to get Jekyll to process the file.
