### PR TITLE
Fix custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "404: Page not found"
+permalink: /404.html
 ---
 
 <div class="page">


### PR DESCRIPTION
According to https://help.github.com/articles/custom-404-pages/
the GitHub Pages 404 must be placed in /404.html. Because of
`permalink: pretty` in _config.yml now a directory named `404`
is generated. Setting the permalink explicitly fixes this.
