### PR TITLE
Change text that points to documentation to "hacking guide"

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ We'd love to have additional help maintaining ctags! Here's a few specific thing
 you can do to help us:
 
 * You can take a look at the [pull requests](https://github.com/universal-ctags/ctags/pulls) and review the proposed changes.
-* [Our documentation](https://github.com/universal-ctags/ctags/tree/master/docs) is pretty sparse. You can help improve it!
+* Our [Hacking Guide](https://github.com/universal-ctags/ctags/tree/master/docs) contains a lot of information on how to build and test ctags.
 * You can [find an issue](https://github.com/universal-ctags/ctags/issues) to work on and submit your own pull request.
 * You can [help us package ctags](https://github.com/universal-ctags/ctags/issues/354) for different platforms.
 


### PR DESCRIPTION
Closes #11
